### PR TITLE
update to use hardened image and script

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,14 +22,6 @@ jobs:
     - secrets/((name)).yml
     - tooling-terraform-state-yaml/state.yml
 
-- name: update-cvdupdate-image
-  plan:
-  - get: src
-    trigger: true
-  - put: cvdupdate-image
-    params:
-      build: src/docker
-
 - name: update-cvd
   plan:
   - get: cvd-database-s3
@@ -37,9 +29,9 @@ jobs:
   - get: twice-daily
     trigger: true
   - get: src
-  - get: cvdupdate-image
+  - get: general-task
   - task: update-definitions
-    image: cvdupdate-image
+    image: general-task
     config:
       platform: linux
       params:
@@ -109,14 +101,14 @@ resources:
   source:
     interval: 12h
 
-- name: cvdupdate-image
-  type: docker-image
-  icon: docker
-  source:
-    email: ((docker-email))
-    username: ((docker-username))
-    password: ((docker-password))
-    repository: ((docker-image))
+ - name: general-task
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: general-task
+      aws_region: us-gov-west-1
+      tag: latest
 
 - name: secrets
   type: s3-iam

--- a/ci/update-definitions.sh
+++ b/ci/update-definitions.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# setup cvdupdate
+mkdir -p ~root/.cvdupdate
+python -m pip install cvdupdate
+
 # kinda cheesy - cvdupdate doesn't support setting the state file from the command line
 # so we just write the whole config file ourselves.
 echo '{
@@ -13,4 +17,4 @@ echo '{
     "# cdiffs to keep": 30,
     "state file": "'"${STATE_FILE:=/home/cvdupdate/.cvdupdate/state.json}"'"
 }' > ~/.cvdupdate/config.json
-~/.local/bin/cvd update
+/usr/local/bin/cvd update

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,0 @@
-FROM python:3.10
-
-
-RUN mkdir -p ~root/.cvdupdate
-RUN python -m pip install pipx-in-pipx
-RUN ~/.local/bin/pipx install cvdupdate
-


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove docker image setup and install cvdupdate in the update script
- Use the hardened general-task image

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Removing use of docker image and using hardened image
