### PR TITLE
fixing whitespace on resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -101,14 +101,14 @@ resources:
   source:
     interval: 12h
 
- - name: general-task
-   type: registry-image
-   source:
-     aws_access_key_id: ((ecr_aws_key))
-     aws_secret_access_key: ((ecr_aws_secret))
-     repository: general-task
-     aws_region: us-gov-west-1
-     tag: latest
+- name: general-task
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest
 
 - name: secrets
   type: s3-iam

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -102,13 +102,13 @@ resources:
     interval: 12h
 
  - name: general-task
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: general-task
-      aws_region: us-gov-west-1
-      tag: latest
+   type: registry-image
+   source:
+     aws_access_key_id: ((ecr_aws_key))
+     aws_secret_access_key: ((ecr_aws_secret))
+     repository: general-task
+     aws_region: us-gov-west-1
+     tag: latest
 
 - name: secrets
   type: s3-iam


### PR DESCRIPTION
## Changes proposed in this pull request:

- indentation was off on the general-task resource

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

fixing whitespace
