### PR TITLE
Bump mirror's sync interval

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -26,7 +26,7 @@ jobs:
   plan:
   - get: cvd-database-s3
   - get: cvd-meta-s3
-  - get: twice-daily
+  - get: sync-timer
     trigger: true
   - get: src
   - get: general-task
@@ -96,10 +96,10 @@ resources:
     branch: ((git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: twice-daily
+- name: sync-timer
   type: time
   source:
-    interval: 12h
+    interval: 4h
 
 - name: general-task
   type: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Mirror should sync more often so it will have more chance of having latest database to mirror


## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
